### PR TITLE
Refactor static argument definitions to support multi-valued argument parsing (prep for bind mount feature)

### DIFF
--- a/args.c
+++ b/args.c
@@ -1,37 +1,80 @@
 #include "util.h"
 #include "args.h"
 
+#define ARG_NONE     no_argument
+#define ARG_REQUIRED required_argument
+#define ARG_OPTIONAL optional_argument
+#define ARG_MULTIPLE required_argument
 
-#define OPSTRING_SEP_0
-#define OPSTRING_SEP_1 ':',
-#define OPSTRING_SEP_2 OPSTRING_SEP_1
-#define OPTSTRING_ITEM(short, long, var, has_arg, type, arg, help) short, OPSTRING_SEP_##has_arg
+
+
+#define OPTSYM_ARG_NONE
+#define OPTSYM_ARG_REQUIRED ':',
+#define OPTSYM_ARG_OPTIONAL OPTSYM_ARG_REQUIRED
+#define OPTSYM_ARG_MULTIPLE OPTSYM_ARG_REQUIRED
+
+#define OPTSTRING_ITEM(short, long, var, has_arg, type, arg, help) short, OPTSYM_##has_arg
 const char optstring[] = { ARGUMENT_LIST(OPTSTRING_ITEM) 'h', '\0' };
-#undef OPTSTRING_ITEM
-#undef OPSTRING_SEP_0
-#undef OPSTRING_SEP_1
-#undef OPSTRING_SEP_2
 
-#define LONGOPT_ITEM(short, long, var, has_arg, type, arg, help) { long, has_arg, NULL, short },
+#undef OPTSTRING_ITEM
+#undef OPTSYM_ARG_NONE
+#undef OPTSYM_ARG_REQUIRED
+#undef OPTSYM_ARG_OPTIONAL
+#undef OPTSYM_ARG_MULTIPLE
+
+
+
+#define LONGOPT_ITEM(short, long, var, has_arg, type, arg, help) \
+    { long, has_arg, NULL, short },
+
 static const struct option long_options[] = {
     ARGUMENT_LIST(LONGOPT_ITEM)
     {"help", 0, NULL , 'h' },
     {NULL, 0, 0, 0}
 };
+
 #undef LONGOPT_ITEM
 
 
-#define HELP_SPACE "18"
+
+#define HELP_SPACE "20"
 #define HELP_ITEM(short, long, var, has_arg, type, arg, help) \
     eprintf("  -%c, --%-"HELP_SPACE"s %s\n", short, long " " #arg, help);
+
 static inline void print_help(const char *prog) {
     eprintf("Usage: %s\n\n", prog);
     eprintf("Arguments:\n");
     eprintf("  -%c, --%-"HELP_SPACE"s %s\n", 'h', "help", "Show this help message and exit.");
     ARGUMENT_LIST(HELP_ITEM)
 }
+
 #undef HELP_ITEM
 #undef HELP_SPACE
+
+
+
+static const char** parse_one_or_many_arg_values(int argc, char *argv[]) {
+    uint args=0, arg_start = --optind;
+    while (optind < argc && argv[optind][0] != '-') {
+        optind++;
+        args++;
+    }
+    if (args == 0) return NULL;
+    const char** arglist = malloc(sizeof(char*[args+1]));
+    for (uint i = 0; i < args; ++i) arglist[i] = argv[arg_start++];
+    arglist[args] = NULL;
+    return arglist;
+}
+
+
+
+#define CASE_ARG_NONE true
+#define CASE_ARG_REQUIRED optarg
+#define CASE_ARG_OPTIONAL optarg
+#define CASE_ARG_MULTIPLE parse_one_or_many_arg_values(argc, argv)
+
+#define PARSE_CASE(short, long, var, has_arg, type, arg, help) \
+    case short : arguments->var = CASE_##has_arg; break;
 
 void parse_args(int argc, char *argv[], Arguments *arguments) {
     int option_index = 0;
@@ -43,16 +86,7 @@ void parse_args(int argc, char *argv[], Arguments *arguments) {
                 print_help(argv[0]);
                 exit(EXIT_SUCCESS);
 
-            #define OPTARG_0 true
-            #define OPTARG_1 optarg
-            #define OPTARG_2 OPTARG_1
-            #define PARSE_CASE(short, long, var, has_arg, type, arg, help) \
-                case short : arguments->var = OPTARG_##has_arg; break;
-                ARGUMENT_LIST(PARSE_CASE)
-            #undef OPTARG_0
-            #undef OPTARG_1
-            #undef OPTARG_2
-            #undef PARSE_CASE
+            ARGUMENT_LIST(PARSE_CASE)
 
             default:
             case '?':
@@ -61,3 +95,9 @@ void parse_args(int argc, char *argv[], Arguments *arguments) {
         }
     }
 }
+
+#undef CASE_ARG_NONE
+#undef CASE_ARG_REQUIRED
+#undef CASE_ARG_OPTIONAL
+#undef CASE_ARG_MULTIPLE
+#undef PARSE_CASE

--- a/args.h
+++ b/args.h
@@ -3,16 +3,19 @@
 
 /* short_flag, long_flag, var_name, has_arg, arg_type, arg_val_name, help */
 #define ARGUMENT_LIST(F) \
-F('i', "id", mount_id, 1, const char*, MOUNT_ID,\
+F('i', "id", mount_id, ARG_REQUIRED, const char*, MOUNT_ID,\
   "Mount ID (defaults to current timestamp)") \
 \
-F('s', "source", source_path, 1, const char*, PATH,\
-  "Path to directory to overlay on top of root filesystem (defaults to ephemeral temporary dir)") \
+F('s', "source", source_path, ARG_REQUIRED, const char*, PATH,\
+  "Path to overlay onto sandbox filesystem. Defaults to an ephemeral temporary dir.") \
 \
-F('c', "cmd", command, 1, const char*, PATH,\
-  "Path to executable command (Defaults to user's preferred shell).") \
+F('c', "cmd", command, ARG_REQUIRED, const char*, COMMAND_STRING ,\
+  "Executable command string (will be word expanded). Defaults to user's preferred shell.") \
 \
-F('v', "verbose", verbose, 0, bool, , "Display extra information")
+F('b', "bind", binds, ARG_MULTIPLE, const char**, PATH [PATH ...],\
+  "Paths to bind mount in the sandbox (i.e. changes to these occur to the actual rootfs).") \
+\
+F('v', "verbose", verbose, ARG_NONE, bool, , "Display extra information")
 
 
 #define STRUCT_ITEM(short, long, var, has_arg, type, arg, help) type var;


### PR DESCRIPTION
Instead of --arg=value this enables support `--arg value1 value2 ...` with human-readable macro name.